### PR TITLE
Stylus supports CSS Modules

### DIFF
--- a/packages/next-stylus/index.js
+++ b/packages/next-stylus/index.js
@@ -17,24 +17,33 @@ module.exports = (nextConfig = {}) => {
         stylusLoaderOptions = {}
       } = nextConfig
 
-      options.defaultLoaders.stylus = cssLoaderConfig(config, {
-        extensions: ['styl'],
-        cssModules,
-        cssLoaderOptions,
-        postcssLoaderOptions,
-        dev,
-        isServer,
-        loaders: [
-          {
-            loader: 'stylus-loader',
-            options: stylusLoaderOptions
-          }
-        ]
-      })
+      const getStylusConfig = isModule => {
+        return cssLoaderConfig(config, {
+          extensions: ['styl'],
+          cssLoaderOptions,
+          cssModules: isModule ? true : cssModules,
+          postcssLoaderOptions,
+          dev,
+          isServer,
+          loaders: [
+            {
+              loader: 'stylus-loader',
+              options: stylusLoaderOptions,
+            },
+          ],
+        })
+      }
+
+      options.defaultLoaders.stylus = getStylusConfig()
+      options.defaultLoaders.stylus_module = getStylusConfig(true)
 
       config.module.rules.push({
-        test: /\.styl$/,
-        use: options.defaultLoaders.stylus
+        test: /(?<!\.module)\.styl$/,
+        use: options.defaultLoaders.stylus,
+      })
+      config.module.rules.push({
+        test: /\.module\.styl$/,
+        use: options.defaultLoaders.stylus_module,
       })
 
       if (typeof nextConfig.webpack === 'function') {


### PR DESCRIPTION
Supports CSS Modules using the [name].module.styl file naming convention.